### PR TITLE
feat(currencies): add diagnostic mmdbg for currencies

### DIFF
--- a/duplicated_symbol_in_used_curr.mmdbg
+++ b/duplicated_symbol_in_used_curr.mmdbg
@@ -1,0 +1,4 @@
+-- MMEX Debug SQL - Read --
+select 'You must not have used currencies with the same symbol.';
+select 'You must update accounts listed below to use only one selected currency with given symbol:';
+select ACCOUNTNAME, ACCOUNTTYPE, STATUS, c2.CURRENCYNAME, c2.CURRENCY_SYMBOL from ACCOUNTLIST_V1 a inner join CURRENCYFORMATS_V1 c2 on a.CURRENCYID = c2.CURRENCYID where a.CURRENCYID in (select c.CURRENCYID from CURRENCYFORMATS_V1 c inner join (select CURRENCY_SYMBOL, COUNT(*) from CURRENCYFORMATS_V1 where CURRENCYID in (select distinct CURRENCYID from ACCOUNTLIST_V1 where CURRENCYID is not null and CURRENCYID <> '') group by CURRENCY_SYMBOL having COUNT(*) > 1) s on c.CURRENCY_SYMBOL = s.CURRENCY_SYMBOL where CURRENCYID in (select distinct CURRENCYID from ACCOUNTLIST_V1 where CURRENCYID is not null and CURRENCYID <> '')) order by c2.CURRENCY_SYMBOL, ACCOUNTNAME;

--- a/empty_symbol_in_used_curr.mmdbg
+++ b/empty_symbol_in_used_curr.mmdbg
@@ -1,0 +1,3 @@
+-- MMEX Debug SQL - Read --
+select 'You must add missing symbol for currencies listed below:';
+select CURRENCYNAME from CURRENCYFORMATS_V1 where (CURRENCY_SYMBOL is null or CURRENCY_SYMBOL = '') and CURRENCYID in (select distinct CURRENCYID from ACCOUNTLIST_V1 where CURRENCYID is not null and CURRENCYID <> '') order by CURRENCYNAME;


### PR DESCRIPTION
This should help users with moneymanagerex/moneymanagerex#1578

```
sqlite> .read empty_symbol_in_used_curr.mmdbg 
                                                        
--------------------------------------------------------
You must add missing symbol for currencies listed below:
CURRENCYNAME
------------
EURO-BELGIUM
EURO-FRANCE 
```

```
sqlite> .read duplicated_symbol_in_used_curr.mmdbg 
                                                       
-------------------------------------------------------
You must not have used currencies with the same symbol.
                                                                                          
------------------------------------------------------------------------------------------
You must update accounts listed below to use only one selected currency with given symbol:
ACCOUNTNAME  ACCOUNTTYPE  STATUS      CURRENCYNAME  CURRENCY_SYMBOL
-----------  -----------  ----------  ------------  ---------------
t5           Checking     Open        EURO-FRANCE                  
t6           Checking     Open        EURO-FRANCE                  
t7           Checking     Open        EURO-FRANCE                  
t8           Checking     Open        EURO-BELGIUM                 
t9           Checking     Open        EURO-BELGIUM                 
t10          Checking     Open        my12          XXR            
t11          Checking     Open        my12          XXR            
t12          Checking     Open        my12          XXR            
t13          Checking     Open        my13          XXR
```