### PR TITLE
fix(#8199): correct quotes in version 21 SQL update statements

### DIFF
--- a/incremental_upgrade/database_version_21.sql
+++ b/incremental_upgrade/database_version_21.sql
@@ -2,7 +2,7 @@
 REINDEX;
 
 -- Yahoo stock URL correction #7736
-UPDATE INFOTABLE_V1 SET INFOVALUE="https://finance.yahoo.com/quote/%s" WHERE INFONAME="STOCKURL" AND INFOVALUE="http://finance.yahoo.com/echarts?s=%s";
+UPDATE INFOTABLE_V1 SET INFOVALUE='https://finance.yahoo.com/quote/%s' WHERE INFONAME='STOCKURL' AND INFOVALUE='http://finance.yahoo.com/echarts?s=%s';
 
 -- Fix currency format for Hungarian Forint #6128
-UPDATE CURRENCYFORMATS_V1 SET SFX_SYMBOL=PFX_SYMBOL, PFX_SYMBOL=""  WHERE CURRENCY_SYMBOL="HUF" AND SFX_SYMBOL="";
+UPDATE CURRENCYFORMATS_V1 SET SFX_SYMBOL=PFX_SYMBOL, PFX_SYMBOL=''  WHERE CURRENCY_SYMBOL='HUF' AND SFX_SYMBOL='';


### PR DESCRIPTION
SQL expects strings to be formatted with single quotes and the double quotes appear to be breaking updates to version 21 of the database. This pull request replaces the appropriate double quotes with single quotes in the upgrade script. If I am understanding how the application generates the update script, this should correct the issue I reported in https://github.com/moneymanagerex/moneymanagerex/issues/8199 on the application repository.